### PR TITLE
Update ControlsResources.xaml & ScrollViewerEx.cs

### DIFF
--- a/ModernWpf/ControlsResources.xaml
+++ b/ModernWpf/ControlsResources.xaml
@@ -53,7 +53,11 @@
     <m:StaticResource x:Key="ContentControlThemeFontFamily" ResourceKey="{x:Static SystemFonts.MessageFontFamilyKey}" />
     <m:StaticResource x:Key="PivotHeaderItemFontFamily" ResourceKey="{x:Static SystemFonts.MessageFontFamilyKey}" />
     <m:StaticResource x:Key="PivotTitleFontFamily" ResourceKey="{x:Static SystemFonts.MessageFontFamilyKey}" />
-    <FontFamily x:Key="SymbolThemeFontFamily">Segoe Fluent Icons,Segoe MDL2 Assets,Segoe UI Symbol</FontFamily>
+    <FontFamily x:Key="SymbolThemeFontFamily">
+        pack://application:,,,/ModernWpf;component/Fonts/#Segoe Fluent Icons,
+        pack://application:,,,/ModernWpf;component/Fonts/#Segoe MDL2 Assets,
+        Segoe UI Symbol
+    </FontFamily>
     <FontFamily x:Key="PhoneFontFamilySemiLight">Segoe WP SemiLight</FontFamily>
     <FontFamily x:Key="PhoneFontFamilyNormal">Segoe WP</FontFamily>
     <sys:Double x:Key="ContentControlFontSize">14</sys:Double>


### PR DESCRIPTION
修复了navigationview在没有Segoe MDL2 Assets字体的电脑上显示方块
 & ScrollViewer在内容高度过高时（大于ScrollViewer高度）滚动速度过快