### PR TITLE
修复文本框强调色不同步问题

### DIFF
--- a/ModernWpf/ThemeResources/Dark.xaml
+++ b/ModernWpf/ThemeResources/Dark.xaml
@@ -2353,7 +2353,7 @@
             <ScaleTransform CenterY="0.5" ScaleY="-1" />
         </LinearGradientBrush.RelativeTransform>
         <LinearGradientBrush.GradientStops>
-            <GradientStop Offset="1.0" Color="{m:ThemeResource SystemAccentColorLight2}" />
+            <GradientStop Offset="1.0" Color="{Binding Color, Source={StaticResource SystemAccentColorLight2Brush}}" />
             <GradientStop Offset="1.0" Color="{m:StaticColor ControlStrokeColorDefault}" />
         </LinearGradientBrush.GradientStops>
     </LinearGradientBrush>

--- a/ModernWpf/ThemeResources/Light.xaml
+++ b/ModernWpf/ThemeResources/Light.xaml
@@ -2360,7 +2360,7 @@
             <ScaleTransform CenterY="0.5" ScaleY="-1" />
         </LinearGradientBrush.RelativeTransform>
         <LinearGradientBrush.GradientStops>
-            <GradientStop Offset="1.0" Color="{m:ThemeResource SystemAccentColorDark1}" />
+            <GradientStop Offset="1.0" Color="{Binding Color, Source={StaticResource SystemAccentColorDark1Brush}}" />
             <GradientStop Offset="1.0" Color="{m:StaticColor ControlStrokeColorDefault}" />
         </LinearGradientBrush.GradientStops>
     </LinearGradientBrush>


### PR DESCRIPTION
在此之前当系统的主题色发生改变时文本框的强调色并不会跟着改变