### PR TITLE
添加UseMicaBackdrop功能

### DIFF
--- a/ModernWpf.Controls/AutoSuggestBox/AutoSuggestBox.xaml
+++ b/ModernWpf.Controls/AutoSuggestBox/AutoSuggestBox.xaml
@@ -57,7 +57,8 @@
                             FontStretch="{TemplateBinding FontStretch}"
                             FontWeight="{TemplateBinding FontWeight}"
                             Foreground="{TemplateBinding Foreground}"
-                            Style="{TemplateBinding TextBoxStyle}" />
+                            Style="{TemplateBinding TextBoxStyle}" 
+                            CaretBrush="{DynamicResource TextControlForegroundFocused}" />
 
                         <Popup
                             x:Name="SuggestionsPopup"

--- a/ModernWpf/Controls/Primitives/WindowHelper.cs
+++ b/ModernWpf/Controls/Primitives/WindowHelper.cs
@@ -175,16 +175,6 @@ namespace ModernWpf.Controls.Primitives
         #region UseMicaBackdrop
         public class ParameterTypes
         {
-            /*
-            [Flags]
-            enum DWM_SYSTEMBACKDROP_TYPE
-            {
-                DWMSBT_MAINWINDOW = 2, // Mica
-                DWMSBT_TRANSIENTWINDOW = 3, // Acrylic
-                DWMSBT_TABBEDWINDOW = 4 // Tabbed
-            }
-            */
-
             [Flags]
             public enum DWMWINDOWATTRIBUTE
             {
@@ -199,7 +189,7 @@ namespace ModernWpf.Controls.Primitives
                 public int cxRightWidth;     // width of right border that retains its size
                 public int cyTopHeight;      // height of top border that retains its size
                 public int cyBottomHeight;   // height of bottom border that retains its size
-            };
+            }
         }
 
         public static class Methods

--- a/ModernWpf/Controls/Primitives/WindowHelper.cs
+++ b/ModernWpf/Controls/Primitives/WindowHelper.cs
@@ -292,102 +292,134 @@ namespace ModernWpf.Controls.Primitives
             bool isSetAcrylic = false;
             bool isSetAero = false;
 
-            void ApplyDarkMode()
-            {
-                var theme = ThemeManager.GetActualTheme(window);
-
-                bool IsDark(ElementTheme theme)
-                {
-                    return theme == ElementTheme.Default
-                        ? ThemeManager.Current.ActualApplicationTheme == ApplicationTheme.Dark
-                        : theme == ElementTheme.Dark;
-                }
-
-                if (IsDark(theme))
-                {
-                    window.ApplyDarkMode();
-                }
-                else
-                {
-                    window.RemoveDarkMode();
-                }
-            }
-
-            var handler = new RoutedEventHandler((sender, e) => ApplyDarkMode());
-
             if (isModern)
             {
-                ApplyDarkMode();
-
-                if (window.IsLoaded)
-                {
-                    window.RemoveTitleBar();
-                }
-                else
-                {
-                    void RemoveTitleBar(object sender, RoutedEventArgs e)
-                    {
-                        window.RemoveTitleBar();
-                    }
-
-                    window.Loaded -= RemoveTitleBar;
-                    window.Loaded += RemoveTitleBar;
-                }
-
-                ThemeManager.RemoveActualThemeChangedHandler(window, handler);
-                ThemeManager.AddActualThemeChangedHandler(window, handler);
+                ApplyDarkMode(window);
+                HandleTitleBar(window);
 
                 if (isUseMica)
                 {
-                    var type = GetSystemBackdropType(window);
-                    if (MicaHelper.IsSupported(type))
-                    {
-                        isSetMica = true;
-                        window.SetResourceReference(FrameworkElement.StyleProperty, MicaWindowStyleKey);
-                    }
+                    isSetMica = SetMicaStyle(window);
                 }
 
                 if (!isSetMica && isUseAcrylic)
                 {
-                    if (AcrylicHelper.IsAcrylicSupported())
-                    {
-                        isSetAcrylic = true;
-                        window.SetResourceReference(FrameworkElement.StyleProperty, AcrylicWindowStyleKey);
-                    }
-                    else if (AcrylicHelper.IsSupported())
-                    {
-                        isSetAcrylic = true;
-                        window.SetResourceReference(FrameworkElement.StyleProperty, AeroWindowStyleKey);
-                    }
+                    isSetAcrylic = SetAcrylicStyle(window);
                 }
 
                 if (!isSetMica && !isSetAcrylic && isUseAero)
                 {
-                    if (new Version(6, 0) <= OSVersionHelper.OSVersion && OSVersionHelper.OSVersion < new Version(6, 2, 8824))
-                    {
-                        isSetAero = true;
-                        window.SetResourceReference(FrameworkElement.StyleProperty, AeroWindowStyleKey);
-                    }
+                    isSetAero = SetAeroStyle(window);
                 }
 
                 if (!isSetMica && !isSetAcrylic && !isSetAero)
                 {
-                    if (OSVersionHelper.IsWindows11OrGreater)
-                    {
-                        window.SetResourceReference(FrameworkElement.StyleProperty, SnapWindowStyleKey);
-                    }
-                    else
-                    {
-                        window.SetResourceReference(FrameworkElement.StyleProperty, DefaultWindowStyleKey);
-                    }
+                    SetDefaultStyle(window);
                 }
             }
             else
             {
-                window.ClearValue(FrameworkElement.StyleProperty);
-                window.RemoveDarkMode();
-                ThemeManager.RemoveActualThemeChangedHandler(window, handler);
+                ClearWindowStyle(window);
+                RemoveDarkMode(window);
             }
+        }
+
+        private static void ApplyDarkMode(Window window)
+        {
+            var theme = ThemeManager.GetActualTheme(window);
+
+            bool IsDark(ElementTheme theme)
+            {
+                return theme == ElementTheme.Default
+                    ? ThemeManager.Current.ActualApplicationTheme == ApplicationTheme.Dark
+                    : theme == ElementTheme.Dark;
+            }
+
+            if (IsDark(theme))
+            {
+                window.ApplyDarkMode();
+            }
+            else
+            {
+                window.RemoveDarkMode();
+            }
+        }
+
+        private static void HandleTitleBar(Window window)
+        {
+            if (window.IsLoaded)
+            {
+                window.RemoveTitleBar();
+            }
+            else
+            {
+                window.Loaded -= RemoveTitleBar;
+                window.Loaded += RemoveTitleBar;
+            }
+        }
+
+        private static void RemoveTitleBar(object sender, RoutedEventArgs e)
+        {
+            var window = (Window)sender;
+            window.RemoveTitleBar();
+        }
+
+        private static bool SetMicaStyle(Window window)
+        {
+            var type = GetSystemBackdropType(window);
+            if (MicaHelper.IsSupported(type))
+            {
+                window.SetResourceReference(FrameworkElement.StyleProperty, MicaWindowStyleKey);
+                return true;
+            }
+            return false;
+        }
+
+        private static bool SetAcrylicStyle(Window window)
+        {
+            if (AcrylicHelper.IsAcrylicSupported())
+            {
+                window.SetResourceReference(FrameworkElement.StyleProperty, AcrylicWindowStyleKey);
+                return true;
+            }
+            else if (AcrylicHelper.IsSupported())
+            {
+                window.SetResourceReference(FrameworkElement.StyleProperty, AeroWindowStyleKey);
+                return true;
+            }
+            return false;
+        }
+
+        private static bool SetAeroStyle(Window window)
+        {
+            if (new Version(6, 0) <= OSVersionHelper.OSVersion && OSVersionHelper.OSVersion < new Version(6, 2, 8824))
+            {
+                window.SetResourceReference(FrameworkElement.StyleProperty, AeroWindowStyleKey);
+                return true;
+            }
+            return false;
+        }
+
+        private static void SetDefaultStyle(Window window)
+        {
+            if (OSVersionHelper.IsWindows11OrGreater)
+            {
+                window.SetResourceReference(FrameworkElement.StyleProperty, SnapWindowStyleKey);
+            }
+            else
+            {
+                window.SetResourceReference(FrameworkElement.StyleProperty, DefaultWindowStyleKey);
+            }
+        }
+
+        private static void ClearWindowStyle(Window window)
+        {
+            window.ClearValue(FrameworkElement.StyleProperty);
+        }
+
+        private static void RemoveDarkMode(Window window)
+        {
+            window.RemoveDarkMode();
         }
     }
 }

--- a/ModernWpf/Controls/Primitives/WindowHelper.cs
+++ b/ModernWpf/Controls/Primitives/WindowHelper.cs
@@ -173,7 +173,7 @@ namespace ModernWpf.Controls.Primitives
         #endregion
 
         #region UseMicaBackdrop
-        public class ParameterTypes
+        public static class Methods
         {
             [Flags]
             public enum DWMWINDOWATTRIBUTE
@@ -181,38 +181,17 @@ namespace ModernWpf.Controls.Primitives
                 DWMWA_USE_IMMERSIVE_DARK_MODE = 20,
                 DWMWA_SYSTEMBACKDROP_TYPE = 38
             }
-
-            [StructLayout(LayoutKind.Sequential)]
-            public struct MARGINS
-            {
-                public int cxLeftWidth;      // width of left border that retains its size
-                public int cxRightWidth;     // width of right border that retains its size
-                public int cyTopHeight;      // height of top border that retains its size
-                public int cyBottomHeight;   // height of bottom border that retains its size
-            }
-        }
-
-        public static class Methods
-        {
-            [DllImport("DwmApi.dll")]
-            static extern int DwmExtendFrameIntoClientArea(
-                IntPtr hwnd,
-                ref ParameterTypes.MARGINS pMarInset);
-
             [DllImport("dwmapi.dll")]
-            static extern int DwmSetWindowAttribute(IntPtr hwnd, ParameterTypes.DWMWINDOWATTRIBUTE dwAttribute, ref int pvAttribute, int cbAttribute);
+            static extern int DwmSetWindowAttribute(IntPtr hwnd, DWMWINDOWATTRIBUTE dwAttribute, ref int pvAttribute, int cbAttribute);
 
-            public static int ExtendFrame(IntPtr hwnd, ParameterTypes.MARGINS margins)
-                => DwmExtendFrameIntoClientArea(hwnd, ref margins);
-
-            public static int SetWindowAttribute(IntPtr hwnd, ParameterTypes.DWMWINDOWATTRIBUTE attribute, int parameter)
+            public static int SetWindowAttribute(IntPtr hwnd, DWMWINDOWATTRIBUTE attribute, int parameter)
                 => DwmSetWindowAttribute(hwnd, attribute, ref parameter, Marshal.SizeOf<int>());
         }
         public static void SetUseMicaBackdrop(Window window)
         {
             Methods.SetWindowAttribute(
                 new WindowInteropHelper(window).Handle,
-                ParameterTypes.DWMWINDOWATTRIBUTE.DWMWA_SYSTEMBACKDROP_TYPE,
+                Methods.DWMWINDOWATTRIBUTE.DWMWA_SYSTEMBACKDROP_TYPE,
                 2);
             RefreshDarkMode(window);
             ThemeManager.Current.ActualApplicationThemeChanged += (s, ev) => RefreshDarkMode(window);
@@ -223,7 +202,7 @@ namespace ModernWpf.Controls.Primitives
             int flag = isDark ? 1 : 0;
             Methods.SetWindowAttribute(
                 new WindowInteropHelper(window).Handle,
-                ParameterTypes.DWMWINDOWATTRIBUTE.DWMWA_USE_IMMERSIVE_DARK_MODE,
+                Methods.DWMWINDOWATTRIBUTE.DWMWA_USE_IMMERSIVE_DARK_MODE,
                 flag);
         }
         #endregion

--- a/ModernWpf/Controls/Primitives/WindowHelper.cs
+++ b/ModernWpf/Controls/Primitives/WindowHelper.cs
@@ -172,6 +172,72 @@ namespace ModernWpf.Controls.Primitives
 
         #endregion
 
+        #region UseMicaBackdrop
+        public class ParameterTypes
+        {
+            /*
+            [Flags]
+            enum DWM_SYSTEMBACKDROP_TYPE
+            {
+                DWMSBT_MAINWINDOW = 2, // Mica
+                DWMSBT_TRANSIENTWINDOW = 3, // Acrylic
+                DWMSBT_TABBEDWINDOW = 4 // Tabbed
+            }
+            */
+
+            [Flags]
+            public enum DWMWINDOWATTRIBUTE
+            {
+                DWMWA_USE_IMMERSIVE_DARK_MODE = 20,
+                DWMWA_SYSTEMBACKDROP_TYPE = 38
+            }
+
+            [StructLayout(LayoutKind.Sequential)]
+            public struct MARGINS
+            {
+                public int cxLeftWidth;      // width of left border that retains its size
+                public int cxRightWidth;     // width of right border that retains its size
+                public int cyTopHeight;      // height of top border that retains its size
+                public int cyBottomHeight;   // height of bottom border that retains its size
+            };
+        }
+
+        public static class Methods
+        {
+            [DllImport("DwmApi.dll")]
+            static extern int DwmExtendFrameIntoClientArea(
+                IntPtr hwnd,
+                ref ParameterTypes.MARGINS pMarInset);
+
+            [DllImport("dwmapi.dll")]
+            static extern int DwmSetWindowAttribute(IntPtr hwnd, ParameterTypes.DWMWINDOWATTRIBUTE dwAttribute, ref int pvAttribute, int cbAttribute);
+
+            public static int ExtendFrame(IntPtr hwnd, ParameterTypes.MARGINS margins)
+                => DwmExtendFrameIntoClientArea(hwnd, ref margins);
+
+            public static int SetWindowAttribute(IntPtr hwnd, ParameterTypes.DWMWINDOWATTRIBUTE attribute, int parameter)
+                => DwmSetWindowAttribute(hwnd, attribute, ref parameter, Marshal.SizeOf<int>());
+        }
+        public static void SetUseMicaBackdrop(Window window)
+        {
+            Methods.SetWindowAttribute(
+                new WindowInteropHelper(window).Handle,
+                ParameterTypes.DWMWINDOWATTRIBUTE.DWMWA_SYSTEMBACKDROP_TYPE,
+                2);
+            RefreshDarkMode(window);
+            ThemeManager.Current.ActualApplicationThemeChanged += (s, ev) => RefreshDarkMode(window);
+        }
+        private static void RefreshDarkMode(Window window)
+        {
+            var isDark = ThemeManager.Current.ActualApplicationTheme == ApplicationTheme.Dark;
+            int flag = isDark ? 1 : 0;
+            Methods.SetWindowAttribute(
+                new WindowInteropHelper(window).Handle,
+                ParameterTypes.DWMWINDOWATTRIBUTE.DWMWA_USE_IMMERSIVE_DARK_MODE,
+                flag);
+        }
+        #endregion
+
         #region SystemBackdropType
 
         public static readonly DependencyProperty SystemBackdropTypeProperty =


### PR DESCRIPTION
原有的SetSystemBackdropType功能在最新版本的Windows11上因为api变动已失效，新增UseMicaBackdrop功能
`WindowHelper.SetUseMicaBackdrop(this);`
加上此代码即可在Windows11上使用Mica效果